### PR TITLE
Fix compatibility with flat packages

### DIFF
--- a/ExportWindowController.m
+++ b/ExportWindowController.m
@@ -19,6 +19,23 @@
 #import "ConfigurationWindowController.h"
 #import "Configuration.h"
 
+@interface ExportWindowController ()
+
+- (BOOL)generateBundlePackageAtPath:(NSString *)outputPackagePath pkgFileName:(NSString *)pkgFileName preinstallPath:(NSString *)preinstallPath;
+- (BOOL)generateFlatPackageAtPath:(NSString *)outputPackagePath pkgFileName:(NSString *)pkgFileName preinstallPath:(NSString *)preinstallPath;
+- (BOOL)writeCustomizationFilesAtResourcesPath:(NSString *)resourcesPath pkgFileName:(NSString *)pkgFileName cleanupPaths:(NSArray *)cleanupPaths;
+- (BOOL)stageFlatCustomizationFilesFromResourcesPath:(NSString *)resourcesPath scriptsPath:(NSString *)scriptsPath pkgFileName:(NSString *)pkgFileName cleanupPaths:(NSArray *)cleanupPaths;
+- (BOOL)copyFileAtPath:(NSString *)sourcePath toPath:(NSString *)targetPath replaceExisting:(BOOL)replaceExisting errorMessageKey:(NSString *)errorMessageKey pkgFileName:(NSString *)pkgFileName cleanupPaths:(NSArray *)cleanupPaths;
+- (BOOL)runCommandAtPath:(NSString *)commandPath arguments:(NSArray *)arguments output:(NSString **)commandOutput;
+- (NSString *)commandFailureCommentWithBaseKey:(NSString *)commentKey output:(NSString *)commandOutput;
+- (NSString *)temporaryWorkspacePath;
+- (NSString *)flatComponentPackagePathAtExpandedPath:(NSString *)expandedPath;
+- (BOOL)isValidFlatPackageAtExpandedPath:(NSString *)expandedPath componentPackagePath:(NSString **)componentPackagePath;
+- (BOOL)cleanupPaths:(NSArray *)paths showWarning:(BOOL)showWarning;
+- (BOOL)displayErrorWithMessage:(NSString *)message comment:(NSString *)comment cleanupPaths:(NSArray *)cleanupPaths;
+
+@end
+
 
 @implementation ExportWindowController
 
@@ -50,12 +67,10 @@
 
 - (IBAction) generatePackage:(id)sender {
     
-    NSMutableString *ocsAgentCfgContent = nil;
-    NSMutableString *modulesCfgContent;
-    NSMutableString *protocolName;
-    NSMutableString *launchdCfgFile;
-    NSString *serverDir;
     NSString *finalMessageComment;
+    NSString *sourcePackagePath = [configuration ocsPkgFilePath];
+    BOOL sourceIsDirectory = NO;
+    BOOL generationSucceeded = NO;
     
     //No export path filled
     if ( !([[exportPath stringValue] length] > 0 )) {
@@ -72,14 +87,12 @@
     
     NSString *pkgFileName = [NSString stringWithFormat:@"%@.pkg",[exportFileName stringValue]];
     NSString *ocsPkgPath = [NSString stringWithFormat:@"%@/%@",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgPluginsPath = [NSString stringWithFormat:@"%@/%@/Contents/Plugins",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgResourcesPath = [NSString stringWithFormat:@"%@/%@/Contents/Resources",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgCfgFilePath = [NSString stringWithFormat:@"%@/%@/Contents/Resources/ocsinventory-agent.cfg",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgModulesFilePath = [NSString stringWithFormat:@"%@/%@/Contents/Resources/modules.conf",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgServerdirFilePath = [NSString stringWithFormat:@"%@/%@/Contents/Resources/serverdir",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgCacertFilePath = [NSString stringWithFormat:@"%@/%@/Contents/Resources/cacert.pem",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgLaunchdFilePath = [NSString stringWithFormat:@"%@/%@/Contents/Resources/org.ocsng.agent.plist",[exportPath stringValue],pkgFileName];
-    NSString *ocsPkgNowFilePath = [NSString stringWithFormat:@"%@/%@/Contents/Resources/now",[exportPath stringValue],pkgFileName];
+    NSString *preinstallPath = [NSString stringWithFormat:@"%@/preinstall",[[NSBundle mainBundle] resourcePath]];
+    
+    if (![filemgr fileExistsAtPath:sourcePackagePath isDirectory:&sourceIsDirectory]) {
+        [context displayAlert:NSLocalizedString(@"Invalid_pkg_file", @"Warning about invalid OCS package file") comment:NSLocalizedString(@"Invalid_pkg_file_comment", @"Warning about invalid OCS package comment") style:NSAlertStyleCritical];
+        return;
+    }
     
     //We check if package already exists
     if ([filemgr fileExistsAtPath:ocsPkgPath]) {
@@ -105,39 +118,139 @@
         }
     }
     
-    //We create new package  file
-    if (![filemgr copyItemAtPath:[configuration ocsPkgFilePath] toPath:ocsPkgPath error:nil]) {
-        // if (![filemgr copyPath:[configuration ocsPkgFilePath] toPath:ocsPkgPath handler:nil]) {
-        [context displayAlert:[NSString stringWithFormat: NSLocalizedString(@"Package_copy_error_warn", @"Warning about package copy error"),pkgFileName] comment:NSLocalizedString(@"Package_copy_error_warn_comment",@"Warning about package copy error comment") style:NSAlertStyleCritical];
+    if (sourceIsDirectory) {
+        generationSucceeded = [self generateBundlePackageAtPath:ocsPkgPath pkgFileName:pkgFileName preinstallPath:preinstallPath];
+    } else {
+        generationSucceeded = [self generateFlatPackageAtPath:ocsPkgPath pkgFileName:pkgFileName preinstallPath:preinstallPath];
+    }
+    
+    if (!generationSucceeded) {
         return;
     }
     
-    //We delete plugins directory for future silent installs
-    if (![self removeFile:ocsPkgPluginsPath]) {
-        [context displayAlert:[NSString stringWithFormat:NSLocalizedString(@"Plugins_remove_error_warn", @"Warning about plugins directory remove error"),pkgFileName] comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment",@"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-        [self removeFile:ocsPkgPath];
-        return;
+    
+    //Everything OK and package generated successfully
+    finalMessageComment = [NSString stringWithFormat:NSLocalizedString(@"Package_succesfully_created_comment",@"Message for succefull created package_comment"), pkgFileName, [exportPath stringValue]];
+    [context displayAlert:NSLocalizedString(@"Package_succesfully_created",@"Message for succefull created package") comment:finalMessageComment style:NSAlertStyleInformational];
+    [NSApp terminate:self];
+}
+
+- (BOOL)generateBundlePackageAtPath:(NSString *)outputPackagePath pkgFileName:(NSString *)pkgFileName preinstallPath:(NSString *)preinstallPath {
+    NSString *resourcesPath = [outputPackagePath stringByAppendingPathComponent:@"Contents/Resources"];
+    NSString *pluginsPath = [outputPackagePath stringByAppendingPathComponent:@"Contents/Plugins"];
+    NSArray *cleanupPaths = [NSArray arrayWithObject:outputPackagePath];
+    
+    if (![filemgr copyItemAtPath:[configuration ocsPkgFilePath] toPath:outputPackagePath error:nil]) {
+        return [self displayErrorWithMessage:[NSString stringWithFormat:NSLocalizedString(@"Package_copy_error_warn", @"Warning about package copy error"),pkgFileName]
+                                     comment:NSLocalizedString(@"Package_copy_error_warn_comment",@"Warning about package copy error comment")
+                                cleanupPaths:cleanupPaths];
     }
     
-    //We copy preinstall and preupgrade scripts
-    NSString *preinstallPath = [NSString stringWithFormat:@"%@/preinstall",[[NSBundle mainBundle] resourcePath]];
-    
-    if ([filemgr fileExistsAtPath:preinstallPath]) {
-        // change from copyPath (deprecated) to copyItemAtPath
-        if (![filemgr copyItemAtPath:preinstallPath toPath:[NSString stringWithFormat:@"%@/preinstall",ocsPkgResourcesPath] error:nil]) {
-            // if (![filemgr copyPath:preinstallPath toPath:[NSString stringWithFormat:@"%@/preinstall",ocsPkgResourcesPath] handler:nil]) {
-            [context displayAlert:NSLocalizedString(@"Preinstall_copy_error_warn",@"Warning about preinstall copy error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-            [self removeFile:ocsPkgPath];
-            return;
-        }
-        
-        // change from copyPath (deprecated) to copyItemAtPath
-        if (![filemgr copyItemAtPath:preinstallPath toPath:[NSString stringWithFormat:@"%@/preupgrade",ocsPkgResourcesPath] error:nil]) {
-            [context displayAlert:NSLocalizedString(@"Preupgrade_copy_error_warn",@"Warning about preupgrade copy error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-            [self removeFile:ocsPkgPath];
-            return;
-        }
+    if (![self removeFile:pluginsPath]) {
+        return [self displayErrorWithMessage:[NSString stringWithFormat:NSLocalizedString(@"Plugins_remove_error_warn", @"Warning about plugins directory remove error"),pkgFileName]
+                                     comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment",@"Warning about package write error comment"),pkgFileName]
+                                cleanupPaths:cleanupPaths];
     }
+    
+    if (![self copyFileAtPath:preinstallPath
+                       toPath:[resourcesPath stringByAppendingPathComponent:@"preinstall"]
+              replaceExisting:YES
+              errorMessageKey:@"Preinstall_copy_error_warn"
+                  pkgFileName:pkgFileName
+                 cleanupPaths:cleanupPaths]) {
+        return NO;
+    }
+    
+    if (![self copyFileAtPath:preinstallPath
+                       toPath:[resourcesPath stringByAppendingPathComponent:@"preupgrade"]
+              replaceExisting:YES
+              errorMessageKey:@"Preupgrade_copy_error_warn"
+                  pkgFileName:pkgFileName
+                 cleanupPaths:cleanupPaths]) {
+        return NO;
+    }
+    
+    return [self writeCustomizationFilesAtResourcesPath:resourcesPath pkgFileName:pkgFileName cleanupPaths:cleanupPaths];
+}
+
+- (BOOL)generateFlatPackageAtPath:(NSString *)outputPackagePath pkgFileName:(NSString *)pkgFileName preinstallPath:(NSString *)preinstallPath {
+    NSString *workspacePath = [self temporaryWorkspacePath];
+    NSString *expandedPath = [workspacePath stringByAppendingPathComponent:@"expanded"];
+    NSString *resourcesPath = [expandedPath stringByAppendingPathComponent:@"Resources"];
+    NSString *componentPackagePath = nil;
+    NSString *scriptsPath = nil;
+    NSString *commandOutput = nil;
+    NSArray *cleanupPaths = [NSArray arrayWithObjects:workspacePath, outputPackagePath, nil];
+    
+    if (![filemgr createDirectoryAtPath:workspacePath withIntermediateDirectories:YES attributes:nil error:nil]) {
+        return [self displayErrorWithMessage:NSLocalizedString(@"Temp_workspace_create_warn", @"Warning about temporary package workspace create error")
+                                     comment:NSLocalizedString(@"Temp_workspace_create_warn_comment", @"Warning about temporary package workspace create error comment")
+                                cleanupPaths:nil];
+    }
+    
+    if (![self runCommandAtPath:@"/usr/sbin/pkgutil"
+                      arguments:[NSArray arrayWithObjects:@"--expand", [configuration ocsPkgFilePath], expandedPath, nil]
+                         output:&commandOutput]) {
+        return [self displayErrorWithMessage:NSLocalizedString(@"Flat_pkg_expand_warn", @"Warning about flat package expand error")
+                                     comment:[self commandFailureCommentWithBaseKey:@"Flat_pkg_expand_warn_comment" output:commandOutput]
+                                cleanupPaths:cleanupPaths];
+    }
+    
+    if (![self isValidFlatPackageAtExpandedPath:expandedPath componentPackagePath:&componentPackagePath]) {
+        return [self displayErrorWithMessage:NSLocalizedString(@"Unsupported_flat_pkg_warn", @"Warning about unsupported flat package")
+                                     comment:NSLocalizedString(@"Unsupported_flat_pkg_warn_comment", @"Warning about unsupported flat package comment")
+                                cleanupPaths:cleanupPaths];
+    }
+    scriptsPath = [componentPackagePath stringByAppendingPathComponent:@"Scripts"];
+    
+    if (![self removeFile:[expandedPath stringByAppendingPathComponent:@"Plugins"]]) {
+        return [self displayErrorWithMessage:[NSString stringWithFormat:NSLocalizedString(@"Plugins_remove_error_warn", @"Warning about plugins directory remove error"),pkgFileName]
+                                     comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment",@"Warning about package write error comment"),pkgFileName]
+                                cleanupPaths:cleanupPaths];
+    }
+    
+    if (![self copyFileAtPath:preinstallPath
+                       toPath:[scriptsPath stringByAppendingPathComponent:@"preinstall"]
+              replaceExisting:YES
+              errorMessageKey:@"Preinstall_copy_error_warn"
+                  pkgFileName:pkgFileName
+                 cleanupPaths:cleanupPaths]) {
+        return NO;
+    }
+    
+    if (![self writeCustomizationFilesAtResourcesPath:resourcesPath pkgFileName:pkgFileName cleanupPaths:cleanupPaths]) {
+        return NO;
+    }
+    
+    if (![self stageFlatCustomizationFilesFromResourcesPath:resourcesPath scriptsPath:scriptsPath pkgFileName:pkgFileName cleanupPaths:cleanupPaths]) {
+        return NO;
+    }
+    
+    commandOutput = nil;
+    if (![self runCommandAtPath:@"/usr/sbin/pkgutil"
+                      arguments:[NSArray arrayWithObjects:@"--flatten", expandedPath, outputPackagePath, nil]
+                         output:&commandOutput]) {
+        return [self displayErrorWithMessage:NSLocalizedString(@"Flat_pkg_flatten_warn", @"Warning about flat package flatten error")
+                                     comment:[self commandFailureCommentWithBaseKey:@"Flat_pkg_flatten_warn_comment" output:commandOutput]
+                                cleanupPaths:cleanupPaths];
+    }
+    
+    [self cleanupPaths:[NSArray arrayWithObject:workspacePath] showWarning:YES];
+    return YES;
+}
+
+- (BOOL)writeCustomizationFilesAtResourcesPath:(NSString *)resourcesPath pkgFileName:(NSString *)pkgFileName cleanupPaths:(NSArray *)cleanupPaths {
+    NSMutableString *ocsAgentCfgContent = nil;
+    NSMutableString *modulesCfgContent = nil;
+    NSMutableString *protocolName = nil;
+    NSMutableString *launchdCfgFile = nil;
+    NSString *serverDir = nil;
+    NSString *cfgFilePath = [resourcesPath stringByAppendingPathComponent:@"ocsinventory-agent.cfg"];
+    NSString *modulesFilePath = [resourcesPath stringByAppendingPathComponent:@"modules.conf"];
+    NSString *serverdirFilePath = [resourcesPath stringByAppendingPathComponent:@"serverdir"];
+    NSString *cacertFilePath = [resourcesPath stringByAppendingPathComponent:@"cacert.pem"];
+    NSString *launchdFilePath = [resourcesPath stringByAppendingPathComponent:@"org.ocsng.agent.plist"];
+    NSString *nowFilePath = [resourcesPath stringByAppendingPathComponent:@"now"];
     
     //We create agent configuration files
     if ([[configuration server] length] > 0) {
@@ -202,12 +315,13 @@
         [ocsAgentCfgContent appendString:@"\n"];
     }
     
-    
-    if(![ocsAgentCfgContent writeToFile:ocsPkgCfgFilePath atomically: YES encoding:NSUTF8StringEncoding error:NULL]) {
-        [context displayAlert:NSLocalizedString(@"Configuration_file_write_error_warn",@"Warning about ocsinventory-agent.cfg file write error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-        [self removeFile:ocsPkgPath];
-        return;
+    if(![ocsAgentCfgContent writeToFile:cfgFilePath atomically:YES encoding:NSUTF8StringEncoding error:NULL]) {
+        [ocsAgentCfgContent release];
+        return [self displayErrorWithMessage:NSLocalizedString(@"Configuration_file_write_error_warn",@"Warning about ocsinventory-agent.cfg file write error")
+                                     comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName]
+                                cleanupPaths:cleanupPaths];
     }
+    [ocsAgentCfgContent release];
     
     //We create modules configuration files
     modulesCfgContent = [@"# this list of module will be load by the at run time\n"
@@ -233,11 +347,13 @@
      @"1;"
      ];
     
-    if (![modulesCfgContent writeToFile:ocsPkgModulesFilePath atomically: YES encoding:NSUTF8StringEncoding error:NULL]) {
-        [context displayAlert:NSLocalizedString(@"Modules_file_write_error_warn",@"Warning about modules.conf file write error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-        [self removeFile:ocsPkgPath];
-        return;
+    if (![modulesCfgContent writeToFile:modulesFilePath atomically:YES encoding:NSUTF8StringEncoding error:NULL]) {
+        [modulesCfgContent release];
+        return [self displayErrorWithMessage:NSLocalizedString(@"Modules_file_write_error_warn",@"Warning about modules.conf file write error")
+                                     comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName]
+                                cleanupPaths:cleanupPaths];
     }
+    [modulesCfgContent release];
     
     
     //We copy cacertfile and create file for server directory creation
@@ -247,13 +363,16 @@
         [protocolName replaceOccurrencesOfString:@"/" withString:@"" options:NSCaseInsensitiveSearch range:NSMakeRange(0, [protocolName length])];
         
         serverDir = [NSString stringWithFormat:@"/var/lib/ocsinventory-agent/%@__%@_ocsinventory", protocolName, [configuration server]];
-        [serverDir writeToFile:ocsPkgServerdirFilePath atomically: YES encoding:NSUTF8StringEncoding error:NULL];
+        [serverDir writeToFile:serverdirFilePath atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+        [protocolName release];
         
-        // change from copyPath (deprecated) to copyItemAtPath
-        if (![filemgr copyItemAtPath:[configuration cacertFilePath] toPath:ocsPkgCacertFilePath error:nil]) {
-            [context displayAlert:NSLocalizedString(@"Cacert_file_copy_error_warn",@"Warning about cacert.pem file copy error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-            [self removeFile:ocsPkgPath];
-            return;
+        if (![self copyFileAtPath:[configuration cacertFilePath]
+                           toPath:cacertFilePath
+                  replaceExisting:YES
+                  errorMessageKey:@"Cacert_file_copy_error_warn"
+                      pkgFileName:pkgFileName
+                     cleanupPaths:cleanupPaths]) {
+            return NO;
         }
     }
     
@@ -297,10 +416,10 @@
             [launchdCfgFile  appendString:@"</integer>\n"];
             
         } else {
-            //Invalid periodificty value
-            [context displayAlert:NSLocalizedString(@"Periodicity_warn", @"Peridocity warn") comment:NSLocalizedString(@"Periodicity_warn_comment", @"Periodicity warn comment") style:NSAlertStyleCritical];
-            [self removeFile:ocsPkgPath];
-            return;
+            [launchdCfgFile release];
+            return [self displayErrorWithMessage:NSLocalizedString(@"Periodicity_warn", @"Peridocity warn")
+                                         comment:NSLocalizedString(@"Periodicity_warn_comment", @"Periodicity warn comment")
+                                    cleanupPaths:cleanupPaths];
         }
     }
     
@@ -308,27 +427,219 @@
      @"</plist>"
      ];
     
-    if (![launchdCfgFile writeToFile:ocsPkgLaunchdFilePath atomically: YES encoding:NSUTF8StringEncoding error:NULL]) {
-        [context displayAlert:NSLocalizedString(@"Launchd_file_write_error_warn",@"Warning about org.ocsng.agent.plit file write error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-        [self removeFile:ocsPkgPath];
-        return;
+    if (![launchdCfgFile writeToFile:launchdFilePath atomically:YES encoding:NSUTF8StringEncoding error:NULL]) {
+        [launchdCfgFile release];
+        return [self displayErrorWithMessage:NSLocalizedString(@"Launchd_file_write_error_warn",@"Warning about org.ocsng.agent.plit file write error")
+                                     comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName]
+                                cleanupPaths:cleanupPaths];
     }
+    [launchdCfgFile release];
     
     
     //We create now file if needed
     if ([configuration now] == 1) {
-        if (![filemgr createFileAtPath:ocsPkgNowFilePath contents:nil attributes:nil]) {
-            [context displayAlert:NSLocalizedString(@"Now_file_write_error_warn",@"Warning about now file write error") comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName] style:NSAlertStyleCritical];
-            [self removeFile:ocsPkgPath];
-            return;
+        if (![filemgr createFileAtPath:nowFilePath contents:nil attributes:nil]) {
+            return [self displayErrorWithMessage:NSLocalizedString(@"Now_file_write_error_warn",@"Warning about now file write error")
+                                         comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName]
+                                    cleanupPaths:cleanupPaths];
         }
     }
     
+    return YES;
+}
+
+- (BOOL)stageFlatCustomizationFilesFromResourcesPath:(NSString *)resourcesPath scriptsPath:(NSString *)scriptsPath pkgFileName:(NSString *)pkgFileName cleanupPaths:(NSArray *)cleanupPaths {
+    NSArray *requiredFiles = [NSArray arrayWithObjects:@"ocsinventory-agent.cfg", @"modules.conf", @"org.ocsng.agent.plist", nil];
+    NSArray *optionalFiles = [NSArray arrayWithObjects:@"serverdir", @"cacert.pem", @"now", nil];
+    NSEnumerator *enumerator = [requiredFiles objectEnumerator];
+    NSString *fileName = nil;
     
-    //Everything OK and package generated succefully
-    finalMessageComment = [NSString stringWithFormat:NSLocalizedString(@"Package_succesfully_created_comment",@"Message for succefull created package_comment"), pkgFileName, [exportPath stringValue]];
-    [context displayAlert:NSLocalizedString(@"Package_succesfully_created",@"Message for succefull created package") comment:finalMessageComment style:NSAlertStyleInformational];
-    [NSApp terminate:self];
+    while ((fileName = [enumerator nextObject])) {
+        NSString *sourcePath = [resourcesPath stringByAppendingPathComponent:fileName];
+        NSString *targetPath = [scriptsPath stringByAppendingPathComponent:fileName];
+        
+        if (![filemgr fileExistsAtPath:sourcePath]) {
+            return [self displayErrorWithMessage:NSLocalizedString(@"Flat_pkg_stage_warn", @"Warning about flat package staging error")
+                                         comment:[NSString stringWithFormat:NSLocalizedString(@"Flat_pkg_stage_warn_comment", @"Warning about flat package staging error comment"), fileName]
+                                    cleanupPaths:cleanupPaths];
+        }
+        
+        if (![self copyFileAtPath:sourcePath
+                           toPath:targetPath
+                  replaceExisting:YES
+                  errorMessageKey:@"Flat_pkg_stage_warn"
+                      pkgFileName:pkgFileName
+                     cleanupPaths:cleanupPaths]) {
+            return NO;
+        }
+    }
+    
+    enumerator = [optionalFiles objectEnumerator];
+    while ((fileName = [enumerator nextObject])) {
+        NSString *sourcePath = [resourcesPath stringByAppendingPathComponent:fileName];
+        NSString *targetPath = [scriptsPath stringByAppendingPathComponent:fileName];
+        
+        if (![filemgr fileExistsAtPath:sourcePath]) {
+            continue;
+        }
+        
+        if (![self copyFileAtPath:sourcePath
+                           toPath:targetPath
+                  replaceExisting:YES
+                  errorMessageKey:@"Flat_pkg_stage_warn"
+                      pkgFileName:pkgFileName
+                     cleanupPaths:cleanupPaths]) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+- (BOOL)copyFileAtPath:(NSString *)sourcePath toPath:(NSString *)targetPath replaceExisting:(BOOL)replaceExisting errorMessageKey:(NSString *)errorMessageKey pkgFileName:(NSString *)pkgFileName cleanupPaths:(NSArray *)cleanupPaths {
+    if (replaceExisting && [filemgr fileExistsAtPath:targetPath]) {
+        if (![filemgr removeItemAtPath:targetPath error:nil]) {
+            return [self displayErrorWithMessage:NSLocalizedString(errorMessageKey, @"Warning about packaged file copy error")
+                                         comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName]
+                                    cleanupPaths:cleanupPaths];
+        }
+    }
+    
+    if (![filemgr copyItemAtPath:sourcePath toPath:targetPath error:nil]) {
+        return [self displayErrorWithMessage:NSLocalizedString(errorMessageKey, @"Warning about packaged file copy error")
+                                     comment:[NSString stringWithFormat:NSLocalizedString(@"Package_write_error_warn_comment", @"Warning about package write error comment"),pkgFileName]
+                                cleanupPaths:cleanupPaths];
+    }
+    
+    return YES;
+}
+
+- (BOOL)runCommandAtPath:(NSString *)commandPath arguments:(NSArray *)arguments output:(NSString **)commandOutput {
+    NSTask *task = [[NSTask alloc] init];
+    NSPipe *pipe = [NSPipe pipe];
+    NSData *commandData;
+    NSString *capturedOutput = @"";
+    BOOL success = NO;
+    
+    [task setLaunchPath:commandPath];
+    [task setArguments:arguments];
+    [task setStandardOutput:pipe];
+    [task setStandardError:pipe];
+    
+    @try {
+        [task launch];
+        [task waitUntilExit];
+        commandData = [[pipe fileHandleForReading] readDataToEndOfFile];
+        if ([commandData length] > 0) {
+            NSString *decodedOutput = [[[NSString alloc] initWithData:commandData encoding:NSUTF8StringEncoding] autorelease];
+            if (decodedOutput) {
+                capturedOutput = decodedOutput;
+            }
+        }
+        success = ([task terminationStatus] == 0);
+    }
+    @catch (NSException *exception) {
+        capturedOutput = [exception reason];
+    }
+    
+    if (commandOutput != NULL) {
+        *commandOutput = capturedOutput;
+    }
+    
+    [task release];
+    return success;
+}
+
+- (NSString *)commandFailureCommentWithBaseKey:(NSString *)commentKey output:(NSString *)commandOutput {
+    NSString *outputString = commandOutput;
+    
+    if (![outputString length]) {
+        outputString = @"";
+    }
+    
+    return [NSString stringWithFormat:NSLocalizedString(commentKey, @"Command failure comment"), outputString];
+}
+
+- (NSString *)temporaryWorkspacePath {
+    return [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"ocs-packager-%@", [[NSProcessInfo processInfo] globallyUniqueString]]];
+}
+
+- (NSString *)flatComponentPackagePathAtExpandedPath:(NSString *)expandedPath {
+    NSArray *expandedContents = [filemgr contentsOfDirectoryAtPath:expandedPath error:nil];
+    NSMutableArray *componentPackages = [NSMutableArray array];
+    NSEnumerator *enumerator = [expandedContents objectEnumerator];
+    NSString *entry = nil;
+    
+    while ((entry = [enumerator nextObject])) {
+        BOOL isDirectory = NO;
+        NSString *entryPath = [expandedPath stringByAppendingPathComponent:entry];
+        
+        if ([[entry pathExtension] isEqualToString:@"pkg"] && [filemgr fileExistsAtPath:entryPath isDirectory:&isDirectory] && isDirectory) {
+            [componentPackages addObject:entryPath];
+        }
+    }
+    
+    if ([componentPackages count] != 1) {
+        return nil;
+    }
+    
+    return [componentPackages objectAtIndex:0];
+}
+
+- (BOOL)isValidFlatPackageAtExpandedPath:(NSString *)expandedPath componentPackagePath:(NSString **)componentPackagePath {
+    BOOL isDirectory = NO;
+    NSString *distributionPath = [expandedPath stringByAppendingPathComponent:@"Distribution"];
+    NSString *resourcesPath = [expandedPath stringByAppendingPathComponent:@"Resources"];
+    NSString *nestedComponentPackagePath = [self flatComponentPackagePathAtExpandedPath:expandedPath];
+    
+    if (![filemgr fileExistsAtPath:distributionPath]) {
+        return NO;
+    }
+    
+    if (![filemgr fileExistsAtPath:resourcesPath isDirectory:&isDirectory] || !isDirectory) {
+        return NO;
+    }
+    
+    if (!nestedComponentPackagePath) {
+        return NO;
+    }
+    
+    isDirectory = NO;
+    if (![filemgr fileExistsAtPath:[nestedComponentPackagePath stringByAppendingPathComponent:@"Scripts"] isDirectory:&isDirectory] || !isDirectory) {
+        return NO;
+    }
+    
+    if (componentPackagePath != NULL) {
+        *componentPackagePath = nestedComponentPackagePath;
+    }
+    
+    return YES;
+}
+
+- (BOOL)cleanupPaths:(NSArray *)paths showWarning:(BOOL)showWarning {
+    NSEnumerator *enumerator = [paths objectEnumerator];
+    NSString *path = nil;
+    
+    while ((path = [enumerator nextObject])) {
+        if ([path length] > 0 && ![self removeFile:path]) {
+            if (showWarning) {
+                [context displayAlert:NSLocalizedString(@"Temp_workspace_cleanup_warn", @"Warning about temporary package workspace cleanup error")
+                              comment:[NSString stringWithFormat:NSLocalizedString(@"Temp_workspace_cleanup_warn_comment", @"Warning about temporary package workspace cleanup error comment"), path]
+                                style:NSAlertStyleCritical];
+            }
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+- (BOOL)displayErrorWithMessage:(NSString *)message comment:(NSString *)comment cleanupPaths:(NSArray *)cleanupPaths {
+    if (cleanupPaths) {
+        [self cleanupPaths:cleanupPaths showWarning:NO];
+    }
+    [context displayAlert:message comment:comment style:NSAlertStyleCritical];
+    return NO;
 }
 
 

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -88,6 +88,42 @@
 //Warning about now file write error
 "Now_file_write_error_warn" = "Error while creating now file !!!";
 
+//Warning about unsupported flat package
+"Unsupported_flat_pkg_warn" = "Unsupported flat OCS package format";
+
+//Warning about unsupported flat package comment
+"Unsupported_flat_pkg_warn_comment" = "The selected flat package does not match the expected UnixAgent layout.";
+
+//Warning about flat package expand error
+"Flat_pkg_expand_warn" = "Error while expanding flat package !!!";
+
+//Warning about flat package expand error comment
+"Flat_pkg_expand_warn_comment" = "Check that the source package is a valid flat package.\n\n%@";
+
+//Warning about flat package flatten error
+"Flat_pkg_flatten_warn" = "Error while rebuilding flat package !!!";
+
+//Warning about flat package flatten error comment
+"Flat_pkg_flatten_warn_comment" = "Check that the temporary package workspace is valid and writable.\n\n%@";
+
+//Warning about flat package resource staging error
+"Flat_pkg_stage_warn" = "Error while staging flat package resources !!!";
+
+//Warning about flat package resource staging error comment
+"Flat_pkg_stage_warn_comment" = "Required file %@ is missing from the temporary flat package workspace.";
+
+//Warning about temporary package workspace create error
+"Temp_workspace_create_warn" = "Error while creating temporary package workspace !!!";
+
+//Warning about temporary package workspace create error comment
+"Temp_workspace_create_warn_comment" = "Check that you have enough permissions to write in the temporary directory.";
+
+//Warning about temporary package workspace cleanup error
+"Temp_workspace_cleanup_warn" = "Error while cleaning temporary package workspace !!!";
+
+//Warning about temporary package workspace cleanup error comment
+"Temp_workspace_cleanup_warn_comment" = "The output package may still have been created, but %@ could not be removed.";
+
 //Message for succefull created package
 "Package_succesfully_created" = "OCS MacOSX agent custom install package successfully created";
 

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -88,6 +88,42 @@
 //Warning about now file write error
 "Now_file_write_error_warn" = "Erreur lors de la création du fichier now !!!";
 
+//Warning about unsupported flat package
+"Unsupported_flat_pkg_warn" = "Format de paquet OCS flat non supporté";
+
+//Warning about unsupported flat package comment
+"Unsupported_flat_pkg_warn_comment" = "Le paquet flat sélectionné ne correspond pas à la structure attendue de l'agent Unix.";
+
+//Warning about flat package expand error
+"Flat_pkg_expand_warn" = "Erreur lors de l'extraction du paquet flat !!!";
+
+//Warning about flat package expand error comment
+"Flat_pkg_expand_warn_comment" = "Vérifiez que le paquet source est bien un paquet flat valide.\n\n%@";
+
+//Warning about flat package flatten error
+"Flat_pkg_flatten_warn" = "Erreur lors de la reconstruction du paquet flat !!!";
+
+//Warning about flat package flatten error comment
+"Flat_pkg_flatten_warn_comment" = "Vérifiez que l'espace de travail temporaire du paquet est valide et accessible en écriture.\n\n%@";
+
+//Warning about flat package resource staging error
+"Flat_pkg_stage_warn" = "Erreur lors de la préparation des ressources du paquet flat !!!";
+
+//Warning about flat package resource staging error comment
+"Flat_pkg_stage_warn_comment" = "Le fichier requis %@ est absent de l'espace de travail temporaire du paquet flat.";
+
+//Warning about temporary package workspace create error
+"Temp_workspace_create_warn" = "Erreur lors de la création de l'espace de travail temporaire du paquet !!!";
+
+//Warning about temporary package workspace create error comment
+"Temp_workspace_create_warn_comment" = "Vérifiez que vous avez les permissions suffisantes pour écrire dans le répertoire temporaire.";
+
+//Warning about temporary package workspace cleanup error
+"Temp_workspace_cleanup_warn" = "Erreur lors du nettoyage de l'espace de travail temporaire du paquet !!!";
+
+//Warning about temporary package workspace cleanup error comment
+"Temp_workspace_cleanup_warn_comment" = "Le paquet de sortie a peut-être bien été créé, mais %@ n'a pas pu être supprimé.";
+
 //Message for succefull created package
 "Package_succesfully_created" = "Le paquet d'installation personnalisée de l'agent OCS MacOSX a été créé avec succès";
 

--- a/ocs_macosx_agent_packager.xcodeproj/project.pbxproj
+++ b/ocs_macosx_agent_packager.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.1;
+				CURRENT_PROJECT_VERSION = 2.2;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
@@ -328,7 +328,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ocsinventory-ng.ocs-macosx-agent-packager";
 				PRODUCT_NAME = ocs_macosx_agent_packager;
 				SDKROOT = macosx;
@@ -343,7 +343,7 @@
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "-";
-				CURRENT_PROJECT_VERSION = 2.1;
+				CURRENT_PROJECT_VERSION = 2.2;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
@@ -358,7 +358,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ocsinventory-ng.ocs-macosx-agent-packager";
 				PRODUCT_NAME = OcsInventory_MacOSX_Packager;
 				SDKROOT = macosx;

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -1,14 +1,19 @@
 #!/bin/sh
 
-#Setting path to package resources directory
-RESOURCES=$1/Contents/Resources
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SOURCE_HINT="${1:-}"
+LEGACY_RESOURCES="$SOURCE_HINT/Contents/Resources"
+SOURCE_PARENT_RESOURCES="$(dirname "$SOURCE_HINT")/../Resources"
+SCRIPT_RESOURCES="$SCRIPT_DIR/Resources"
+SCRIPT_PARENT_RESOURCES="$SCRIPT_DIR/../Resources"
+SCRIPT_GRANDPARENT_RESOURCES="$SCRIPT_DIR/../../Resources"
 
 #Setting temp directory
-if [ $3 ]  #If run from NetInstall
+if [ -n "${3:-}" ]  #If run from NetInstall
 then
-  TMP_DIR=$3/tmp/ocs_installer
+  TMP_DIR="$3/tmp/ocs_installer"
 else
-  TMP_DIR=/tmp/ocs_installer
+  TMP_DIR="/tmp/ocs_installer"
 fi
 
 #Files we want to copy
@@ -19,36 +24,72 @@ SERVERDIR_CFG_PATH="serverdir"
 NOW_PATH="now"
 CACERT_PATH="cacert.pem"
 
+resolve_source_file() {
+  FILE_NAME="$1"
+
+  for CANDIDATE_DIR in \
+    "$SCRIPT_DIR" \
+    "$SCRIPT_RESOURCES" \
+    "$SCRIPT_PARENT_RESOURCES" \
+    "$SCRIPT_GRANDPARENT_RESOURCES" \
+    "$LEGACY_RESOURCES" \
+    "$SOURCE_PARENT_RESOURCES"
+  do
+    if [ -f "$CANDIDATE_DIR/$FILE_NAME" ]
+    then
+      echo "$CANDIDATE_DIR/$FILE_NAME"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+copy_staged_file() {
+  SOURCE_FILE="$1"
+  FILE_NAME="$2"
+
+  if ! cp "$SOURCE_FILE" "$TMP_DIR/$FILE_NAME"
+  then
+    echo "ERROR: failed to copy $FILE_NAME from $SOURCE_FILE to $TMP_DIR" >&2
+    exit 1
+  fi
+}
+
+copy_required_file() {
+  FILE_NAME="$1"
+  SOURCE_FILE=$(resolve_source_file "$FILE_NAME")
+  if [ -z "$SOURCE_FILE" ]
+  then
+    echo "ERROR: required installer file $FILE_NAME was not found in supported resource locations" >&2
+    exit 1
+  fi
+
+  copy_staged_file "$SOURCE_FILE" "$FILE_NAME"
+}
+
+copy_optional_file() {
+  FILE_NAME="$1"
+  SOURCE_FILE=$(resolve_source_file "$FILE_NAME")
+  if [ -z "$SOURCE_FILE" ]
+  then
+    return 0
+  fi
+
+  copy_staged_file "$SOURCE_FILE" "$FILE_NAME"
+}
 
 #Create temporary dir neeeded by postinstall script
-mkdir -p $TMP_DIR 
-
-if [ -f $RESOURCES/$AGENT_CFG_PATH ]
+if ! mkdir -p "$TMP_DIR"
 then
-  cp $RESOURCES/$AGENT_CFG_PATH $TMP_DIR 
+  echo "ERROR: failed to create temporary staging directory $TMP_DIR" >&2
+  exit 1
 fi
 
-if [ -f $RESOURCES/$MODULES_CFG_PATH ]
-then
-  cp $RESOURCES/$MODULES_CFG_PATH $TMP_DIR
-fi
+copy_required_file "$AGENT_CFG_PATH"
+copy_required_file "$MODULES_CFG_PATH"
+copy_required_file "$LAUNCHD_CFG_PATH"
 
-if [ -f $RESOURCES/$LAUNCHD_CFG_PATH ]
-then
-  cp $RESOURCES/$LAUNCHD_CFG_PATH $TMP_DIR
-fi
-
-if [ -f $RESOURCES/$SERVERDIR_CFG_PATH ]
-then
-  cp $RESOURCES/$SERVERDIR_CFG_PATH $TMP_DIR
-fi
-
-if [ -f $RESOURCES/$NOW_PATH ] 
-then
-  cp $RESOURCES/$NOW_PATH $TMP_DIR
-fi
-
-if [ -f $RESOURCES/$CACERT_PATH ]
-then
-  cp $RESOURCES/$CACERT_PATH $TMP_DIR 
-fi
+copy_optional_file "$SERVERDIR_CFG_PATH"
+copy_optional_file "$NOW_PATH"
+copy_optional_file "$CACERT_PATH"


### PR DESCRIPTION
The 2.10.4 of the agent changed the bundle format for flat due to compatibility reasons (Tahoe 26+)
Both bundle and flat will be supported with this packager version, the output respecting the format of the initial .pkg file it packages